### PR TITLE
fix: make sure `visits` include "recent" and "ever" keys for db init :fire: 

### DIFF
--- a/ckanext/googleanalytics/utils/ga.py
+++ b/ckanext/googleanalytics/utils/ga.py
@@ -84,7 +84,7 @@ def save_packages_data(packages_data):
     for identifier, visits in packages_data.items():
         matches = RESOURCE_URL_REGEX.match(identifier)
         
-        if matches:
+        if matches and "recent" in visits.keys() and "ever" in visits.keys():
             resource_url = identifier.replace(matches.group(1), "")
             package_id = matches.group(2)
             resource_id = matches.group(3)


### PR DESCRIPTION
## Description

I tried to deploy to AFRO staging and I got a `KeyError` saying that the `visits` object had no `recent` key.

I do not understand this plugin well enough to know why this scenario would occur; however, as I needed to deploy I have introduced this :fire: hot fix :fire: 

*Important:* this may not be the correct fix so I have assigned @ntwalibas so that he can properly investigate this

relates fjelltopp/ckanext-who-afro#89
relates fjelltopp/who-afro-ckan#

## Dependency Changes

See who-afro-ckan and specifically fjelltopp/who-afro-ckan#

## Testing

Local dev environment and staging deployed through Azure Pipelines now work.

## Checklist

- [ ] The GitHub ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [x] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
